### PR TITLE
fix bugs for handle dirreq

### DIFF
--- a/tests/single_client1.sh
+++ b/tests/single_client1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ./bin/server --directory tests/example_dir/
+# server --directory=tests/example_dir/
 # This script is used to test the single client accessing scenario.
 
 URL="http://localhost:8080"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+scripts=("single_client1.sh" "single_client2.sh" "single_client3.sh" "single_client4.sh" "multi_client1.sh" "multi_client2.sh" "multi_client3.sh" "multi_client4.sh")
+
+for script in "${scripts[@]}"; do
+    chmod +x "$script"
+
+    echo "Running $script..."
+    ./"$script"
+
+    if [ $? -ne 0 ]; then
+        echo "$script failed to execute."
+        exit 1
+    fi
+done
+
+echo "All scripts executed successfully."


### PR DESCRIPTION
When listing directory, some of files won't getting showed correctly. Some files will show up twice, some files will not getting showed, some files will have an extra '>' at the end. Should be fixed now